### PR TITLE
fix(ci): hv1-core is x86_64-only, so keep it out of the ARM lane

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -74,8 +74,14 @@ jobs:
               with:
                   repo-token: ${{ secrets.GITHUB_TOKEN }}
 
+            # hv1-core is the x86_64 Type-1 hypervisor and says so itself: its
+            # lib.rs carries a compile_error! refusing any other architecture,
+            # pointing at hv1-arm instead. macos-latest is ARM64, so it has to
+            # be excluded there -- and only there. On the x86_64 runners it is
+            # built and tested like every other crate, which is the point of
+            # having removed the blanket exclusions in #70.
             - name: Run tests
-              run: cargo test --workspace --exclude hv2-core
+              run: cargo test --workspace --exclude hv2-core ${{ runner.arch == 'ARM64' && '--exclude hv1-core' || '' }}
 
     test-core:
         name: Test Core (Linux only)


### PR DESCRIPTION
`master` is red on `Test (macos-latest)`, and it is my doing.

#70 removed `--exclude hv1-core` from every stable lane, on the grounds that the crate builds and tests fine on stable once its `x86_64` dependency stops asking for nightly features. That was right for the x86_64 runners and wrong for `macos-latest`, which is ARM64:

```
error: hv1-core is the x86_64 (Intel VMX / AMD SVM) Type-1 hypervisor and does not
build for other architectures. The ARM64 EL2 hypervisor is the separate `hv1-arm`
crate; depend on that instead.
 --> crates/hv1-core/src/lib.rs:59
```

The crate refuses non-x86 targets with an explicit `compile_error!`, so the exclusion I deleted was load-bearing on exactly one runner in the matrix. This restores it there and only there, conditioned on `runner.arch`, so Linux and Windows keep testing the crate — 161 tests — rather than going back to skipping it.

**Why it was not caught:** `hv1-core` had been excluded from every lane, so nothing had built it on ARM in a long time and the architecture constraint was invisible. Removing the exclusions surfaced a real constraint rather than creating one — the same shape as the rest of that work, with me on the receiving end this time.

**Scope:** only the matrixed `test` job needs it. `build-cli` compiles `hm-cli` and `hv2-cli` by name and never reaches `hv1-core`; every other workspace-wide lane runs on `ubuntu-latest`.

Verified the YAML parses. The real check is this PR's own `Test (macos-latest)` job going green.