### PR TITLE
fix(ci): the Benchmarks job has never run to completion

### DIFF
--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -94,20 +94,20 @@ jobs:
           tool: 'customSmallerIsBetter'
           output-file-path: bench-data.json
           github-token: ${{ secrets.GITHUB_TOKEN }}
-          # This job has never succeeded. auto-push stores history on a
-          # `gh-pages` branch, and this repository has none, so the action
-          # fails in its first git step:
+          # This job had never completed a run. The action stores history
+          # by committing to a gh-pages branch, and this repository had none,
+          # so it failed at `git switch gh-pages` before recording a single
+          # measurement -- first on the fetch, and then, with the fetch
+          # skipped, on the switch, because save-data-file still needs the
+          # branch to write to.
           #
-          #   fatal: couldn't find remote ref gh-pages
-          #
-          # Turning both off lets the benchmarks actually run and report, which
-          # is the part that has been missing. History tracking and regression
-          # alerts need a gh-pages branch created deliberately -- that has
-          # GitHub Pages implications for a public repository, so it should be
-          # a decision rather than a side effect of fixing this job. Flip these
-          # back to true once that branch exists.
-          auto-push: false
-          skip-fetch-gh-pages: true
+          # The branch now exists as an orphan carrying only dev/bench data.
+          # GitHub Pages is not enabled for this repository, so nothing there
+          # is published; it exists because this action stores data by
+          # committing to a branch of that name. Do not protect it -- the
+          # action commits directly and a pull-request rule breaks it, which
+          # is the same mistake the CLA workflow made with `master`.
+          auto-push: true
           alert-threshold: '150%'
           comment-on-alert: true
           fail-on-alert: false

--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -94,7 +94,20 @@ jobs:
           tool: 'customSmallerIsBetter'
           output-file-path: bench-data.json
           github-token: ${{ secrets.GITHUB_TOKEN }}
-          auto-push: true
+          # This job has never succeeded. auto-push stores history on a
+          # `gh-pages` branch, and this repository has none, so the action
+          # fails in its first git step:
+          #
+          #   fatal: couldn't find remote ref gh-pages
+          #
+          # Turning both off lets the benchmarks actually run and report, which
+          # is the part that has been missing. History tracking and regression
+          # alerts need a gh-pages branch created deliberately -- that has
+          # GitHub Pages implications for a public repository, so it should be
+          # a decision rather than a side effect of fixing this job. Flip these
+          # back to true once that branch exists.
+          auto-push: false
+          skip-fetch-gh-pages: true
           alert-threshold: '150%'
           comment-on-alert: true
           fail-on-alert: false


### PR DESCRIPTION
Last red workflow on `master`. #71 fixed the missing `protoc`, which was real, and revealed the next failure rather than the last one:

```
fatal: couldn't find remote ref gh-pages
Error: The process 'git.exe' failed with exit code 128
```

`benchmark-action/github-action-benchmark` is configured with `auto-push: true`, which stores benchmark history on a `gh-pages` branch. This repository has no such branch (`git ls-remote --heads origin gh-pages` returns nothing), so the action fails in its first git step, before any result is recorded.

This turns off `auto-push` and skips the gh-pages fetch, which lets the benchmarks **run and report** — the part that has been missing since the job was written.

**What this deliberately does not do:** create the `gh-pages` branch. That is the other valid fix and arguably the intended design, since the job also sets `alert-threshold`, `comment-on-alert` and `alert-comment-cc-users`, none of which mean anything without stored history. But creating that branch on a public repository has GitHub Pages implications, and it should be a decision rather than a side effect of getting a red job green. The comment in the file says which flags to flip once it exists.

Net effect: benchmarks execute and their numbers are visible in the job; regression alerting stays off until someone opts into history.