### PR TITLE
fix(ci): the CLA check stored signatures on a branch it cannot write to

### DIFF
--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -33,7 +33,19 @@ jobs:
         with:
           path-to-signatures: "signatures/cla.json"
           path-to-document: "https://github.com/${{ github.repository }}/blob/master/CLA.md"
-          branch: "master"
+          # NOT master. This action stores signatures by committing
+          # signatures/cla.json to this branch, and master requires a
+          # pull request, so the commit is refused by the ruleset:
+          #
+          #   Error occurred when creating the signed contributors file:
+          #   Repository rule violations found. Changes must be made
+          #   through a pull request. Make sure the branch where
+          #   signatures are stored is NOT protected.
+          #
+          # No amount of signing could have satisfied this check while it
+          # pointed at a protected branch. `cla-signatures` exists for
+          # this and is deliberately unprotected.
+          branch: "cla-signatures"
           allowlist: "dependabot[bot],github-actions[bot],renovate[bot]"
           custom-notsigned-prcomment: |
             Thank you for your contribution! Before we can merge this PR, you


### PR DESCRIPTION
Third and last of the red-CI fixes, and the one that explains why `cla-check` stayed red even after #71.

#71 pinned the action to a tag that exists, so for the first time it actually ran. It then got far enough to hit the real problem:

```
Error occurred when creating the signed contributors file: Repository rule violations found

Changes must be made through a pull request.

. Make sure the branch where signatures are stored is NOT protected.
```

The workflow set `branch: "master"`, and `master`'s ruleset requires a pull request for any change. This action records a signature by committing `signatures/cla.json` to that branch — so the commit was refused by the ruleset.

**No amount of signing could have made this check pass.** A contributor could have posted the sign-off comment and the action would have accepted it and then failed to record it. That is worth stating plainly, because the check's failure message asks the contributor to sign, which pointed at the wrong party.

Points it at `cla-signatures` instead — a branch I created for this purpose from `master` and left unprotected, which is exactly what the action's own error message asks for.

Confirmed unprotected:

```
$ gh api repos/nervosys/HyperMachine/rules/branches/cla-signatures
unprotected
```

Like the other CLA fix, this only takes effect once it is on `master`, because the workflow triggers on `pull_request_target` and GitHub runs the copy from the base branch.