### PR TITLE
fix(ci): the baseline comparison failed builds on measurement noise

### DIFF
--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -102,11 +102,18 @@ jobs:
           # branch to write to.
           #
           # The branch now exists as an orphan carrying only dev/bench data.
-          # GitHub Pages is not enabled for this repository, so nothing there
-          # is published; it exists because this action stores data by
-          # committing to a branch of that name. Do not protect it -- the
-          # action commits directly and a pull-request rule breaks it, which
-          # is the same mistake the CLA workflow made with `master`.
+          #
+          # Note that this branch IS published. An earlier version of this
+          # comment claimed GitHub Pages was not enabled here; it is, with
+          # `source.branch` set to `gh-pages`, so everything the action
+          # commits appears at nervosys.github.io/HyperMachine/dev/bench/.
+          # The 404 that suggested otherwise comes from the Pages builds
+          # failing, not from Pages being off. Whatever is stored here is
+          # public.
+          #
+          # Do not protect the branch -- the action commits directly and a
+          # pull-request rule breaks it, which is the same mistake the CLA
+          # workflow made with `master`.
           #
           # Only pushes write history. Once the branch existed, every event
           # wrote to it, so 18 of the first 20 stored measurements came from

--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -107,7 +107,17 @@ jobs:
           # committing to a branch of that name. Do not protect it -- the
           # action commits directly and a pull-request rule breaks it, which
           # is the same mistake the CLA workflow made with `master`.
-          auto-push: true
+          #
+          # Only pushes write history. Once the branch existed, every event
+          # wrote to it, so 18 of the first 20 stored measurements came from
+          # pull-request branches -- including branches since deleted. The
+          # baseline this job compares against was therefore mostly other
+          # people's unmerged work, which is a better explanation for the
+          # comparison failures than runner noise alone. A pull request still
+          # runs the benchmarks and still gets its comparison comment; it just
+          # no longer records itself as history for the next run to measure
+          # against.
+          auto-push: ${{ github.event_name == 'push' }}
           alert-threshold: '150%'
           comment-on-alert: true
           fail-on-alert: false

--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -210,11 +210,32 @@ jobs:
           cargo bench -p hv2-core --bench crypto_bench -- --noplot --baseline baseline | Tee-Object -FilePath comparison.txt
         continue-on-error: true
 
-      - name: Check for regressions
+      # Reported, not enforced, and the distinction matters here.
+      #
+      # This greps criterion's text for the word "regressed" and used to exit 1
+      # on a match, with no threshold: a 1% wobble failed the build exactly as
+      # a 200% regression would. Criterion prints that line for any benchmark
+      # measured slower than its baseline, and the two runs being compared
+      # happen on one shared CI runner, minutes apart, with a full rebuild in
+      # between -- so noise produces it on most runs.
+      #
+      # The evidence it was noise: this failed identically on three Dependabot
+      # PRs bumping a Terraform provider, a Docker base image and
+      # tock-registers, none of which can affect hv2-core's crypto benchmarks.
+      # It only became visible now because the job `needs: benchmark`, and that
+      # job had never completed a run.
+      #
+      # Real regression alerting already exists, with a threshold and a
+      # baseline built from stored history: github-action-benchmark in the job
+      # above, at alert-threshold 150%. This step is here to put the numbers in
+      # front of a reviewer, which it now does without failing the build for
+      # having measured something on a busy machine.
+      - name: Report regressions
         run: |
           if (Select-String -Path pr/comparison.txt -Pattern "regressed" -Quiet) {
-            Write-Warning "Performance regressions detected!"
+            Write-Warning "Criterion reports slower measurements than baseline. On a shared runner this is usually noise -- compare against the alert-threshold job before treating it as real:"
             Get-Content pr/comparison.txt | Select-String "regressed"
-            exit 1
+          } else {
+            Write-Output "No benchmarks measured slower than baseline."
           }
 


### PR DESCRIPTION
Fixing the Benchmarks job in #74 made this one visible for the first time. `benchmark-comparison` declares `needs: benchmark`, and that job had never completed a run — so this comparison had never executed either.

It greps criterion's output for the word `regressed` and exited 1 on a match, **with no threshold**. Criterion prints that line for any benchmark measured slower than its baseline, however slightly, and the two runs being compared happen on one shared CI runner, minutes apart, with a full rebuild between them. A 1% wobble failed the build exactly as a 200% regression would.

**The evidence that this is noise rather than signal:** it failed identically, with a dozen `Performance has regressed` lines, on three Dependabot PRs bumping a Terraform provider (#72), a Docker base image (#62) and `tock-registers` (#48). None of those can affect `hv2-core`'s crypto benchmarks. Those three are otherwise **31 green, 0 failed** after rebasing onto the repaired master — this is the only thing standing between them and a clean run.

Worth noting too: every other step in that job already carries `continue-on-error: true`, so it tolerated the benchmarks themselves failing and then failed on noise in their output.

Real regression alerting already exists, with a threshold and a baseline drawn from stored history — `github-action-benchmark` at `alert-threshold: 150%` in the job above, which #74 made functional. This step's value is putting numbers in front of a reviewer, which it still does; it just no longer fails a build for having measured something on a busy machine.