### PR TITLE
deps: windows-sys 0.59 -> 0.61

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3090,7 +3090,7 @@ dependencies = [
  "toml",
  "tracing",
  "tracing-subscriber",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
  "zeroize",
 ]
 
@@ -3139,7 +3139,7 @@ dependencies = [
  "thiserror 2.0.20",
  "tokio",
  "tracing",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3170,7 +3170,7 @@ dependencies = [
  "serde",
  "thiserror 2.0.20",
  "tracing",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/crates/hv2-core/Cargo.toml
+++ b/crates/hv2-core/Cargo.toml
@@ -46,7 +46,7 @@ slh-dsa = { version = "=0.2.0-rc.5", optional = true }
 libc = "0.2"
 
 [target.'cfg(windows)'.dependencies]
-windows-sys = { version = "0.59", features = [
+windows-sys = { version = "0.61", features = [
     "Win32_Foundation",
     "Win32_System_Threading",
     "Win32_System_Memory",

--- a/crates/hv2-net/Cargo.toml
+++ b/crates/hv2-net/Cargo.toml
@@ -29,7 +29,7 @@ libc = "0.2"
 libc = "0.2"
 
 [target.'cfg(windows)'.dependencies]
-windows-sys = { version = "0.59", features = [
+windows-sys = { version = "0.61", features = [
     "Win32_Storage_FileSystem",
     "Win32_Foundation",
     "Win32_System_IO",

--- a/crates/hv2-sandbox/Cargo.toml
+++ b/crates/hv2-sandbox/Cargo.toml
@@ -20,7 +20,7 @@ tracing = { workspace = true }
 libc = "0.2"
 
 [target.'cfg(windows)'.dependencies]
-windows-sys = { version = "0.59", features = [
+windows-sys = { version = "0.61", features = [
     "Win32_Foundation",
     "Win32_Security",
     "Win32_System_JobObjects",

--- a/crates/hv2-sandbox/src/process/windows.rs
+++ b/crates/hv2-sandbox/src/process/windows.rs
@@ -28,7 +28,8 @@ use std::os::windows::io::AsRawHandle;
 use std::os::windows::process::CommandExt;
 use std::process::{Command, Stdio};
 
-use windows_sys::Win32::Foundation::{CloseHandle, BOOL, HANDLE, INVALID_HANDLE_VALUE};
+use windows_sys::core::BOOL;
+use windows_sys::Win32::Foundation::{CloseHandle, HANDLE, INVALID_HANDLE_VALUE};
 use windows_sys::Win32::System::Diagnostics::ToolHelp::{
     CreateToolhelp32Snapshot, Thread32First, Thread32Next, TH32CS_SNAPTHREAD, THREADENTRY32,
 };


### PR DESCRIPTION
Dependabot opened #50 for this and it sat conflicted on `Cargo.lock`.

Three crates declare `windows-sys` under `cfg(windows)`: `hv2-core`, `hv2-net` and `hv2-sandbox`. The feature names they ask for are unchanged in 0.61, and `hv2-core` and `hv2-net` compile against it untouched.

`hv2-sandbox` does not. **`BOOL` moved out of `Win32::Foundation` into `windows_sys::core`**, which is what `SetInformationJobObject` returns in 0.61, so `process/windows.rs` imports it from there. That is the whole source change — and it is why Dependabot's own attempt fails both its Windows lanes with:

```
error[E0432]: unresolved import `windows_sys::Win32::Foundation::BOOL`
error: could not compile `hv2-sandbox` (lib) due to 1 previous error
```

## Verification

Run on Windows, which is where these `cfg(windows)` dependencies actually build:

| check | result |
| --- | --- |
| `cargo clippy --workspace --all-targets -- -D warnings` | silent |
| `cargo test -p hv2-sandbox -p hv2-net` | all pass |

Closes #50.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RsopUtvfyNzkKbbte56vZv