### PR TITLE
chore: remove wasmtime, and the WASM claims that had no code behind them

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -197,12 +197,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
 
 [[package]]
-name = "ambient-authority"
-version = "0.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e9d4ee0d472d1cd2e28c97dfa124b3d8d992e10eb0a035f33f5d12e3a177ba3b"
-
-[[package]]
 name = "android-activity"
 version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -297,15 +291,6 @@ name = "anyhow"
 version = "1.0.104"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "330a5ed07fa54e4702c9d6c4174f74427fc0ef6e214bbd677ae50a5099946470"
-
-[[package]]
-name = "ar_archive_writer"
-version = "0.5.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "73cd58deff2140a0a8eae87e417bd01db68a33e148aa93d1e8cd837e55e312b6"
-dependencies = [
- "object 0.39.1",
-]
 
 [[package]]
 name = "arbitrary"
@@ -957,84 +942,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "cap-fs-ext"
-version = "3.4.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d5528f85b1e134ae811704e41ef80930f56e795923f866813255bc342cc20654"
-dependencies = [
- "cap-primitives",
- "cap-std",
- "io-lifetimes",
- "windows-sys 0.59.0",
-]
-
-[[package]]
-name = "cap-net-ext"
-version = "3.4.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "20a158160765c6a7d0d8c072a53d772e4cb243f38b04bfcf6b4939cfbe7482e7"
-dependencies = [
- "cap-primitives",
- "cap-std",
- "rustix 1.1.4",
- "smallvec",
-]
-
-[[package]]
-name = "cap-primitives"
-version = "3.4.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b6cf3aea8a5081171859ef57bc1606b1df6999df4f1110f8eef68b30098d1d3a"
-dependencies = [
- "ambient-authority",
- "fs-set-times",
- "io-extras",
- "io-lifetimes",
- "ipnet",
- "maybe-owned",
- "rustix 1.1.4",
- "rustix-linux-procfs",
- "windows-sys 0.59.0",
- "winx",
-]
-
-[[package]]
-name = "cap-rand"
-version = "3.4.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d8144c22e24bbcf26ade86cb6501a0916c46b7e4787abdb0045a467eb1645a1d"
-dependencies = [
- "ambient-authority",
- "rand 0.8.7",
-]
-
-[[package]]
-name = "cap-std"
-version = "3.4.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b6dc3090992a735d23219de5c204927163d922f42f575a0189b005c62d37549a"
-dependencies = [
- "cap-primitives",
- "io-extras",
- "io-lifetimes",
- "rustix 1.1.4",
-]
-
-[[package]]
-name = "cap-time-ext"
-version = "3.4.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "def102506ce40c11710a9b16e614af0cde8e76ae51b1f48c04b8d79f4b671a80"
-dependencies = [
- "ambient-authority",
- "cap-primitives",
- "iana-time-zone",
- "once_cell",
- "rustix 1.1.4",
- "winx",
-]
-
-[[package]]
 name = "cast"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1162,7 +1069,7 @@ version = "4.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d012d2b9d65aca7f18f4d9878a045bc17899bba951561ba5ec3c2ba1eed9a061"
 dependencies = [
- "heck 0.5.0",
+ "heck",
  "proc-macro2",
  "quote",
  "syn 3.0.3",
@@ -1197,15 +1104,6 @@ name = "cmov"
 version = "0.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0c9ea0ac24bc397ab3c98583a3c9ba74fa56b09a4449bbe172b9b1ddb016027a"
-
-[[package]]
-name = "cobs"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0fa961b519f0b462e3a3b4a34b64d119eeaca1d59af726fe450bbba07a9fc0a1"
-dependencies = [
- "thiserror 2.0.20",
-]
 
 [[package]]
 name = "codespan-reporting"
@@ -1372,128 +1270,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b2a41393f66f16b0823bb79094d54ac5fbd34ab292ddafb9a0456ac9f87d201"
 dependencies = [
  "libc",
-]
-
-[[package]]
-name = "cranelift-bforest"
-version = "0.111.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9f1e0fcfc3fd9bb13e7a81d6eb0e54fb686923e2ea54a1ef4a402f86038581a1"
-dependencies = [
- "cranelift-entity",
-]
-
-[[package]]
-name = "cranelift-bitset"
-version = "0.111.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f55a030ea8d8d986720e3e810987159188839219e8d2939da3d670a914ac9e22"
-dependencies = [
- "serde",
- "serde_derive",
-]
-
-[[package]]
-name = "cranelift-codegen"
-version = "0.111.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c79622b0af2d613ad58361bd0c12e944736c7afaf82836fc2957233928ea1b4e"
-dependencies = [
- "bumpalo",
- "cranelift-bforest",
- "cranelift-bitset",
- "cranelift-codegen-meta",
- "cranelift-codegen-shared",
- "cranelift-control",
- "cranelift-entity",
- "cranelift-isle",
- "gimli",
- "hashbrown 0.14.5",
- "log",
- "regalloc2",
- "rustc-hash 1.1.0",
- "smallvec",
- "target-lexicon",
-]
-
-[[package]]
-name = "cranelift-codegen-meta"
-version = "0.111.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e916e029a2c069e01a1cff036a25663b367a2308b9da764250cca709f5b4f283"
-dependencies = [
- "cranelift-codegen-shared",
-]
-
-[[package]]
-name = "cranelift-codegen-shared"
-version = "0.111.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "78c002b476f41b62fb3298a6f6f49c12d7daa298ba12b01cc362114d4c8fa880"
-
-[[package]]
-name = "cranelift-control"
-version = "0.111.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "522f7dc283e9108d37566996fadf8ec78b9aeb0ee695b59110bcd2ca7313c045"
-dependencies = [
- "arbitrary",
-]
-
-[[package]]
-name = "cranelift-entity"
-version = "0.111.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9b85d1acc3f05f86262767f57455bc98981e05e4b0549f7452e9f8c54c4824f0"
-dependencies = [
- "cranelift-bitset",
- "serde",
- "serde_derive",
-]
-
-[[package]]
-name = "cranelift-frontend"
-version = "0.111.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "83362d9277692c79419d211f8d1dd5d1d1a0585f487ce51f1bad58edad5192d0"
-dependencies = [
- "cranelift-codegen",
- "log",
- "smallvec",
- "target-lexicon",
-]
-
-[[package]]
-name = "cranelift-isle"
-version = "0.111.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "003431de90f4005f1fe422b83120bf870de5f1d9a9908517e1f7786b8d7a0c51"
-
-[[package]]
-name = "cranelift-native"
-version = "0.111.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "15e26db1bb1c4b5bc08d771c77cad687866260dbb6b64bcd8fc01d51f9fe7ef1"
-dependencies = [
- "cranelift-codegen",
- "libc",
- "target-lexicon",
-]
-
-[[package]]
-name = "cranelift-wasm"
-version = "0.111.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d5a52a1e1ef74bbe394d48bdc691cf3daf685ec8e0059946d84abf1ec6bf438d"
-dependencies = [
- "cranelift-codegen",
- "cranelift-entity",
- "cranelift-frontend",
- "itertools 0.12.1",
- "log",
- "smallvec",
- "wasmparser",
- "wasmtime-types",
 ]
 
 [[package]]
@@ -1903,18 +1679,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "embedded-io"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ef1a6892d9eef45c8fa6b9e0086428a2cca8491aca8f787c534a3d6d0bcb3ced"
-
-[[package]]
-name = "embedded-io"
-version = "0.6.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "edd0f118536f44f5ccd48bcb8b111bdc3de888b58c74639dfb034a357d0f206d"
-
-[[package]]
 name = "encoding_rs"
 version = "0.8.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2102,12 +1866,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "fallible-iterator"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2acce4a10f12dc2fb14a218589d4f1f62ef011b2d0cc4b3cb1bba8e94da14649"
-
-[[package]]
 name = "fastrand"
 version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2118,17 +1876,6 @@ name = "fax"
 version = "0.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "caf1079563223d5d59d83c85886a56e586cfd5c1a26292e971a0fa266531ac5a"
-
-[[package]]
-name = "fd-lock"
-version = "4.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ce92ff622d6dadf7349484f42c93271a0d49b7cc4d466a936405bacbe10aa78"
-dependencies = [
- "cfg-if",
- "rustix 1.1.4",
- "windows-sys 0.59.0",
-]
 
 [[package]]
 name = "fdeflate"
@@ -2247,35 +1994,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "fs-set-times"
-version = "0.20.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94e7099f6313ecacbe1256e8ff9d617b75d1bcb16a6fddef94866d225a01a14a"
-dependencies = [
- "io-lifetimes",
- "rustix 1.1.4",
- "windows-sys 0.59.0",
-]
-
-[[package]]
 name = "fs_extra"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42703706b716c37f96a77aea830392ad231f44c9e9a67872fa5548707e11b11c"
-
-[[package]]
-name = "futures"
-version = "0.3.34"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a31d2a3fbaaeb2af2368bbdd904aa8e812d3c04a1ee10d3171f52d556e5d0a3"
-dependencies = [
- "futures-channel",
- "futures-core",
- "futures-io",
- "futures-sink",
- "futures-task",
- "futures-util",
-]
 
 [[package]]
 name = "futures-channel"
@@ -2284,7 +2006,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b1f9e3d69d39e4862ffed03ed071a76f9a13ba1d9109d355b0f0aa6b15e393c4"
 dependencies = [
  "futures-core",
- "futures-sink",
 ]
 
 [[package]]
@@ -2418,17 +2139,6 @@ checksum = "ee8cfcc411d9adbbaba82fb72661cc1bcca13e8bba98b364e62b2dba8f960159"
 dependencies = [
  "color_quant",
  "weezl",
-]
-
-[[package]]
-name = "gimli"
-version = "0.29.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "40ecd4077b5ae9fd2e9e169b102c6c330d0605168eb0e8bf79952b256dbefffd"
-dependencies = [
- "fallible-iterator",
- "indexmap",
- "stable_deref_trait",
 ]
 
 [[package]]
@@ -2604,25 +2314,6 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
-version = "0.13.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43a3c133739dddd0d2990f9a4bdf8eb4b21ef50e4851ca85ab661199821d510e"
-dependencies = [
- "ahash",
-]
-
-[[package]]
-name = "hashbrown"
-version = "0.14.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
-dependencies = [
- "ahash",
- "serde",
-]
-
-[[package]]
-name = "hashbrown"
 version = "0.15.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
@@ -2649,12 +2340,6 @@ checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
 dependencies = [
  "foldhash 0.2.0",
 ]
-
-[[package]]
-name = "heck"
-version = "0.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "95505c38b4572b2d910cecb0281560f54b440a19336cbbcb27bf6ce6adc6f5a8"
 
 [[package]]
 name = "heck"
@@ -2823,8 +2508,6 @@ dependencies = [
  "tokio",
  "tracing",
  "tracing-subscriber",
- "wasmtime",
- "wasmtime-wasi",
 ]
 
 [[package]]
@@ -3232,12 +2915,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "id-arena"
-version = "2.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d3067d79b975e8844ca9eb072e16b31c3c1c36928edf9c6789548c524d0d954"
-
-[[package]]
 name = "idna"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3325,8 +3002,6 @@ checksum = "d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9"
 dependencies = [
  "equivalent",
  "hashbrown 0.17.1",
- "serde",
- "serde_core",
 ]
 
 [[package]]
@@ -3339,22 +3014,6 @@ dependencies = [
  "quote",
  "syn 2.0.119",
 ]
-
-[[package]]
-name = "io-extras"
-version = "0.18.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2285ddfe3054097ef4b2fe909ef8c3bcd1ea52a8f0d274416caebeef39f04a65"
-dependencies = [
- "io-lifetimes",
- "windows-sys 0.59.0",
-]
-
-[[package]]
-name = "io-lifetimes"
-version = "2.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "06432fb54d3be7964ecd3649233cddf80db2832f47fec34c01f65b3d9d774983"
 
 [[package]]
 name = "ipnet"
@@ -3384,15 +3043,6 @@ name = "itertools"
 version = "0.10.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b0fd2260e829bddf4cb6ea802289de2f86d6a7a690192fbe91b3f46e0f2c8473"
-dependencies = [
- "either",
-]
-
-[[package]]
-name = "itertools"
-version = "0.12.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba291022dbbd398a455acf126c1e341954079855bc60dfdda641363bd6922569"
 dependencies = [
  "either",
 ]
@@ -3559,12 +3209,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "leb128"
-version = "0.2.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c83bff1d572d6b9aeef67ddfc8448e4a3737909cb28e81f97c791b9018703e52"
-
-[[package]]
 name = "lebe"
 version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3684,15 +3328,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
 
 [[package]]
-name = "mach2"
-version = "0.4.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d640282b302c0bb0a2a8e0233ead9035e3bed871f0b7e81fe4a1ec829765db44"
-dependencies = [
- "libc",
-]
-
-[[package]]
 name = "matchers"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3706,12 +3341,6 @@ name = "matchit"
 version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "47e1ffaa40ddd1f3ed91f717a33c8c0ee23fff369e3aa8772b9605cc1d22f4c3"
-
-[[package]]
-name = "maybe-owned"
-version = "0.3.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4facc753ae494aeb6e3c22f839b158aebd4f9270f55cd3c79906c45476c47ab4"
 
 [[package]]
 name = "maybe-rayon"
@@ -3728,15 +3357,6 @@ name = "memchr"
 version = "2.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf8baf1c55e62ffcace7a9f06f4bd9cd3f0c4beb022d3b367256b91b87513d98"
-
-[[package]]
-name = "memfd"
-version = "0.6.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ad38eb12aea514a0466ea40a80fd8cc83637065948eb4a426e4aa46261175227"
-dependencies = [
- "rustix 1.1.4",
-]
 
 [[package]]
 name = "memmap2"
@@ -4412,27 +4032,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "object"
-version = "0.36.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62948e14d923ea95ea2c7c86c71013138b66525b86bdc08d2dcc262bdb497b87"
-dependencies = [
- "crc32fast",
- "hashbrown 0.15.5",
- "indexmap",
- "memchr",
-]
-
-[[package]]
-name = "object"
-version = "0.39.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2e5a6c098c7a3b6547378093f5cc30bc54fd361ce711e05293a5cc589562739b"
-dependencies = [
- "memchr",
-]
-
-[[package]]
 name = "once_cell"
 version = "1.21.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4879,18 +4478,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "postcard"
-version = "1.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6764c3b5dd454e283a30e6dfe78e9b31096d9e32036b5d1eaac7a6119ccb9a24"
-dependencies = [
- "cobs",
- "embedded-io 0.4.0",
- "embedded-io 0.6.1",
- "serde",
-]
-
-[[package]]
 name = "potential_utf"
 version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4996,7 +4583,7 @@ version = "0.14.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "03da047801ff44bb6a4d407d4860c05fd70bb81714e6b2f3812603d5b145b042"
 dependencies = [
- "heck 0.5.0",
+ "heck",
  "itertools 0.14.0",
  "log",
  "multimap",
@@ -5031,16 +4618,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f94967dc7688f3054c7fac87473ffae4cc4c3904800e2d9f5b857246d8963b0a"
 dependencies = [
  "prost",
-]
-
-[[package]]
-name = "psm"
-version = "0.1.32"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4dcd034599e63b970727f70d79e02d62390a4a84f7c6b827c27c46d5ac3fa622"
-dependencies = [
- "ar_archive_writer",
- "cc",
 ]
 
 [[package]]
@@ -5205,7 +4782,6 @@ version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "22f6172bdec972074665ed81ed53b71da00bfc44b65a753cfde883ec4c702a1a"
 dependencies = [
- "libc",
  "rand_chacha 0.3.1",
  "rand_core 0.6.4",
 ]
@@ -5461,19 +5037,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "regalloc2"
-version = "0.9.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ad156d539c879b7a24a363a2016d77961786e71f48f2e2fc8302a92abd2429a6"
-dependencies = [
- "hashbrown 0.13.2",
- "log",
- "rustc-hash 1.1.0",
- "slice-group-by",
- "smallvec",
-]
-
-[[package]]
 name = "regex"
 version = "1.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5708,16 +5271,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "rustix-linux-procfs"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2fc84bf7e9aa16c4f2c758f27412dc9841341e16aa682d9c7ac308fe3ee12056"
-dependencies = [
- "once_cell",
- "rustix 1.1.4",
-]
-
-[[package]]
 name = "rustls"
 version = "0.23.43"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5856,10 +5409,6 @@ name = "semver"
 version = "1.0.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a7852d02fc848982e0c167ef163aaff9cd91dc640ba85e263cb1ce46fae51cd"
-dependencies = [
- "serde",
- "serde_core",
-]
 
 [[package]]
 name = "serde"
@@ -6119,12 +5668,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "slice-group-by"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "826167069c09b99d56f31e9ae5c99049e932a98c9dc2dac47645b08dbbf76ba7"
-
-[[package]]
 name = "slotmap"
 version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6301,12 +5844,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a0219bd7d979d58245a4f41f695e1ac9f8befdffadd7f61f1bae9e39abc6620"
 
 [[package]]
-name = "sptr"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b9b39299b249ad65f3b7e96443bad61c02ca5cd3589f46cb6d610a0fd6c0d6a"
-
-[[package]]
 name = "stable_deref_trait"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6398,28 +5935,6 @@ dependencies = [
  "core-foundation-sys",
  "libc",
 ]
-
-[[package]]
-name = "system-interface"
-version = "0.27.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cc4592f674ce18521c2a81483873a49596655b179f71c5e05d10c1fe66c78745"
-dependencies = [
- "bitflags 2.13.1",
- "cap-fs-ext",
- "cap-std",
- "fd-lock",
- "io-lifetimes",
- "rustix 0.38.44",
- "windows-sys 0.59.0",
- "winx",
-]
-
-[[package]]
-name = "target-lexicon"
-version = "0.12.16"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "61c41af27dd6d1e27b1b16b489db798443478cef1f06a660c96db617ba5de3b1"
 
 [[package]]
 name = "tempfile"
@@ -7019,12 +6534,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7dd6e30e90baa6f72411720665d41d89b9a3d039dc45b8faea1ddd07f617f6af"
 
 [[package]]
-name = "unicode-xid"
-version = "0.2.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
-
-[[package]]
 name = "untrusted"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7231,282 +6740,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7ef64dbcc55df09c7e5a46182d181c2cfa3e925f3da937ea764728b4bbb9dcbf"
 dependencies = [
  "unicode-ident",
-]
-
-[[package]]
-name = "wasm-encoder"
-version = "0.215.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4fb56df3e06b8e6b77e37d2969a50ba51281029a9aeb3855e76b7f49b6418847"
-dependencies = [
- "leb128",
-]
-
-[[package]]
-name = "wasmparser"
-version = "0.215.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "53fbde0881f24199b81cf49b6ff8f9c145ac8eb1b7fc439adb5c099734f7d90e"
-dependencies = [
- "ahash",
- "bitflags 2.13.1",
- "hashbrown 0.14.5",
- "indexmap",
- "semver",
- "serde",
-]
-
-[[package]]
-name = "wasmprinter"
-version = "0.215.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d8e9a325d85053408209b3d2ce5eaddd0dd6864d1cff7a007147ba073157defc"
-dependencies = [
- "anyhow",
- "termcolor",
- "wasmparser",
-]
-
-[[package]]
-name = "wasmtime"
-version = "24.0.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a13d6802706c07f231c7838b0db5b74f919c6c85bb394eb55356f0ad5002c780"
-dependencies = [
- "anyhow",
- "async-trait",
- "bitflags 2.13.1",
- "bumpalo",
- "cc",
- "cfg-if",
- "encoding_rs",
- "hashbrown 0.14.5",
- "indexmap",
- "libc",
- "libm",
- "log",
- "mach2",
- "memfd",
- "object 0.36.7",
- "once_cell",
- "paste",
- "postcard",
- "psm",
- "rustix 0.38.44",
- "semver",
- "serde",
- "serde_derive",
- "smallvec",
- "sptr",
- "target-lexicon",
- "wasmparser",
- "wasmtime-asm-macros",
- "wasmtime-component-macro",
- "wasmtime-component-util",
- "wasmtime-cranelift",
- "wasmtime-environ",
- "wasmtime-fiber",
- "wasmtime-jit-icache-coherence",
- "wasmtime-slab",
- "wasmtime-versioned-export-macros",
- "wasmtime-winch",
- "windows-sys 0.52.0",
-]
-
-[[package]]
-name = "wasmtime-asm-macros"
-version = "24.0.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a40476b014935908f9c22dd37dfa7626fea6709aac22886134aa54d97d88ba0c"
-dependencies = [
- "cfg-if",
-]
-
-[[package]]
-name = "wasmtime-component-macro"
-version = "24.0.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "82b2be41416042fef06931bf74aca8ac4593ee3bd8c2fa0557643104ca1cc0eb"
-dependencies = [
- "anyhow",
- "proc-macro2",
- "quote",
- "syn 2.0.119",
- "wasmtime-component-util",
- "wasmtime-wit-bindgen",
- "wit-parser",
-]
-
-[[package]]
-name = "wasmtime-component-util"
-version = "24.0.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "867d68d728c8da1a0dff766539d3b42f3d12f56c449a2eac36779a62ad07af1e"
-
-[[package]]
-name = "wasmtime-cranelift"
-version = "24.0.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "98b7ffc88728060b73989899cb1499eabd1933174c7ec2ef7a9fc871f34cec95"
-dependencies = [
- "anyhow",
- "cfg-if",
- "cranelift-codegen",
- "cranelift-control",
- "cranelift-entity",
- "cranelift-frontend",
- "cranelift-native",
- "cranelift-wasm",
- "gimli",
- "log",
- "object 0.36.7",
- "target-lexicon",
- "thiserror 1.0.69",
- "wasmparser",
- "wasmtime-environ",
- "wasmtime-versioned-export-macros",
-]
-
-[[package]]
-name = "wasmtime-environ"
-version = "24.0.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "63e333246cda0228bea352116609cbd95df61cfab46ad6328aeca5ca7931ab38"
-dependencies = [
- "anyhow",
- "cranelift-bitset",
- "cranelift-entity",
- "gimli",
- "indexmap",
- "log",
- "object 0.36.7",
- "postcard",
- "semver",
- "serde",
- "serde_derive",
- "target-lexicon",
- "wasm-encoder",
- "wasmparser",
- "wasmprinter",
- "wasmtime-component-util",
- "wasmtime-types",
-]
-
-[[package]]
-name = "wasmtime-fiber"
-version = "24.0.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f539b759b17676524059085d29e20c5ed443369e6fd7d42ecb99105603eb7a63"
-dependencies = [
- "anyhow",
- "cc",
- "cfg-if",
- "rustix 0.38.44",
- "wasmtime-asm-macros",
- "wasmtime-versioned-export-macros",
- "windows-sys 0.52.0",
-]
-
-[[package]]
-name = "wasmtime-jit-icache-coherence"
-version = "24.0.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f005888881e8f9f24c393970c0d20be851c3b84c7558ed05e80c0d65b6692a2"
-dependencies = [
- "anyhow",
- "cfg-if",
- "libc",
- "windows-sys 0.52.0",
-]
-
-[[package]]
-name = "wasmtime-slab"
-version = "24.0.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fd1cb6634ae85994158a587699b595c708cac5abef305bed645b15f7c6dd1675"
-
-[[package]]
-name = "wasmtime-types"
-version = "24.0.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d2d6f662565dd1e5e74c967d496c84094a0d2885ef4f3d477e4a06e9b7904fb5"
-dependencies = [
- "anyhow",
- "cranelift-entity",
- "serde",
- "serde_derive",
- "smallvec",
- "wasmparser",
-]
-
-[[package]]
-name = "wasmtime-versioned-export-macros"
-version = "24.0.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ee2055bd9a442cee6efd32f4b6b37e75f6e888a1b9994ec9ec1ab85c6813adfb"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.119",
-]
-
-[[package]]
-name = "wasmtime-wasi"
-version = "24.0.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "914d95ae640944b72549839b79e16c1c438ce9f589d281049b478336015a1fa6"
-dependencies = [
- "anyhow",
- "async-trait",
- "bitflags 2.13.1",
- "bytes",
- "cap-fs-ext",
- "cap-net-ext",
- "cap-rand",
- "cap-std",
- "cap-time-ext",
- "fs-set-times",
- "futures",
- "io-extras",
- "io-lifetimes",
- "once_cell",
- "rustix 0.38.44",
- "system-interface",
- "thiserror 1.0.69",
- "tokio",
- "tracing",
- "url",
- "wasmtime",
- "windows-sys 0.52.0",
-]
-
-[[package]]
-name = "wasmtime-winch"
-version = "24.0.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "346c85c5b15c7007a5451e8570b8abfafc5f19c2373f63c471afc0b7da0e4404"
-dependencies = [
- "anyhow",
- "cranelift-codegen",
- "gimli",
- "object 0.36.7",
- "target-lexicon",
- "wasmparser",
- "wasmtime-cranelift",
- "wasmtime-environ",
- "winch-codegen",
-]
-
-[[package]]
-name = "wasmtime-wit-bindgen"
-version = "24.0.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d8dfc9cbc67420d0d51bdbfc032354ce73470640a492a74bdb8d3b1f0934dd4"
-dependencies = [
- "anyhow",
- "heck 0.4.1",
- "indexmap",
- "wit-parser",
 ]
 
 [[package]]
@@ -7885,23 +7118,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
  "windows-sys 0.61.2",
-]
-
-[[package]]
-name = "winch-codegen"
-version = "0.22.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "70ede50bb2705a1e542134312c28659f84afd7c98f634c97c41ef777dcfc2827"
-dependencies = [
- "anyhow",
- "cranelift-codegen",
- "gimli",
- "regalloc2",
- "smallvec",
- "target-lexicon",
- "wasmparser",
- "wasmtime-cranelift",
- "wasmtime-environ",
 ]
 
 [[package]]
@@ -8318,38 +7534,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "winx"
-version = "0.36.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f3fd376f71958b862e7afb20cfe5a22830e1963462f3a17f49d82a6c1d1f42d"
-dependencies = [
- "bitflags 2.13.1",
- "windows-sys 0.59.0",
-]
-
-[[package]]
 name = "wit-bindgen"
 version = "0.57.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1ebf944e87a7c253233ad6766e082e3cd714b5d03812acc24c318f549614536e"
-
-[[package]]
-name = "wit-parser"
-version = "0.215.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "935a97eaffd57c3b413aa510f8f0b550a4a9fe7d59e79cd8b89a83dcb860321f"
-dependencies = [
- "anyhow",
- "id-arena",
- "indexmap",
- "log",
- "semver",
- "serde",
- "serde_derive",
- "serde_json",
- "unicode-xid",
- "wasmparser",
-]
 
 [[package]]
 name = "writeable"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -120,11 +120,6 @@ criterion = "0.5"
 
 # Scripting for AI agents
 rhai = { version = "1.19", features = ["sync"] }
-# Note: wasmtime is currently optional (off by default) because no source code uses it yet.
-# Enable via the `wasm-scripts` feature on hv2-agent when wiring up a WASM scripting backend.
-# Keeping it out of default builds eliminates multiple wasmtime CVE exposures (RUSTSEC-2026-0085..96).
-wasmtime = { version = "24.0", default-features = false }
-wasmtime-wasi = { version = "24.0", default-features = false }
 
 # Compression
 flate2 = "1.0"

--- a/crates/hv2-agent/Cargo.toml
+++ b/crates/hv2-agent/Cargo.toml
@@ -30,15 +30,9 @@ rand = { workspace = true }
 
 # Scripting engines
 rhai = { workspace = true }
-# wasmtime is reserved for a future WASM scripting backend; opt-in via `wasm-scripts` feature.
-# Not pulled into default builds — eliminates wasmtime CVE exposure (RUSTSEC-2026-0085..96).
-wasmtime = { workspace = true, optional = true }
-wasmtime-wasi = { workspace = true, optional = true }
 
 [features]
 default = []
-# Reserved: enables wasmtime-based scripting engine. No source currently uses it.
-wasm-scripts = ["dep:wasmtime", "dep:wasmtime-wasi"]
 
 # Security (Linux only - commented out for Windows compatibility)
 # seccompiler = "0.4"

--- a/crates/hv2-api/src/ontology.rs
+++ b/crates/hv2-api/src/ontology.rs
@@ -1459,7 +1459,7 @@ impl HyperMachineOntology {
                     "properties": {
                         "id": { "type": "string", "format": "uuid" },
                         "vm_id": { "type": "string", "format": "uuid" },
-                        "script_type": { "type": "string", "enum": ["rhai", "wasm"] },
+                        "script_type": { "type": "string", "enum": ["rhai"] },
                         "state": { "type": "string", "enum": ["pending", "running", "completed", "failed"] },
                         "output": { "type": "string" },
                         "error": { "type": "string" },
@@ -1835,13 +1835,13 @@ impl HyperMachineOntology {
                         "properties": {
                             "script_type": { 
                                 "type": "string", 
-                                "enum": ["rhai", "wasm"],
+                                "enum": ["rhai"],
                                 "default": "rhai",
-                                "description": "Script runtime: 'rhai' for dynamic scripts, 'wasm' for compiled modules"
+                                "description": "Script runtime. Rhai is the only one implemented."
                             },
                             "script": { 
                                 "type": "string",
-                                "description": "Script content (Rhai source code or base64-encoded WASM)"
+                                "description": "Rhai source code"
                             },
                             "timeout_seconds": {
                                 "type": "integer",
@@ -2583,8 +2583,9 @@ impl HyperMachineOntology {
                 AgentSkill {
                     id: "agent_scripting".to_string(),
                     name: "Agent Script Execution".to_string(),
-                    description: "Execute Rhai or WASM scripts in sandboxed VM environments"
-                        .to_string(),
+                    description:
+                        "Execute Rhai scripts on the host against a read-only view of a VM"
+                            .to_string(),
                     tags: vec![
                         "agent".to_string(),
                         "script".to_string(),

--- a/deny.toml
+++ b/deny.toml
@@ -9,12 +9,12 @@ db-urls = ["https://github.com/rustsec/advisory-db"]
 
 # Ignore specific advisories (with justification)
 ignore = [
-    # bincode 1.x is unmaintained but used by bootloader crate
-    # We only use it in build-time dependencies
+    # bincode 1.x is unmaintained. hv2-core depends on it directly, for
+    # snapshot serialisation; it is stable and carries no known advisory.
     "RUSTSEC-2025-0141",
 
     # paste is archived but has no known vulnerabilities
-    # Used as transitive dep by wasmtime/cranelift
+    # Used as a transitive dep by image/rav1e, reached through eframe in hm-gui
     "RUSTSEC-2024-0436",
 
     # Marvin Attack: timing sidechannel in the pure-Rust `rsa` crate.

--- a/docs/AGENTIC_ONTOLOGY.md
+++ b/docs/AGENTIC_ONTOLOGY.md
@@ -126,7 +126,7 @@ Control VM execution state.
 Execute sandboxed scripts within VMs.
 
 **Operations:**
-- `execute_script` - Run a Rhai or WASM script
+- `execute_script` - Run a Rhai script on the host against a read-only view of a VM
 - `list_agents` - List active agents
 - `get_agent_logs` - Get agent execution logs
 

--- a/docs/security/MITRE_ATTACK_MAPPING.md
+++ b/docs/security/MITRE_ATTACK_MAPPING.md
@@ -57,21 +57,19 @@ async fn authenticate(req: Request) -> Result<AuthenticatedRequest> {
 | Sub-Technique          | Risk | Mitigation                | Status      |
 | ---------------------- | ---- | ------------------------- | ----------- |
 | T1059.006 - Python     | N/A  | Not supported             | N/A         |
-| T1059.007 - JavaScript | Low  | WASM sandboxed            | ✅ Mitigated |
+| T1059.007 - JavaScript | N/A  | Not supported             | N/A         |
 | Custom - Rhai          | Low  | Sandboxed, no FFI         | ✅ Mitigated |
-| Custom - WASM          | Low  | wasmtime capability-based | ✅ Mitigated |
 
 **Agent Sandbox Controls:**
 ```rust
-// WASM capability restrictions (hv2-agent)
-let config = Config::new();
-config.wasm_component_model(true);
-config.consume_fuel(true);  // CPU limiting
-config.epoch_interruption(true);  // Timeout control
+// Rhai engine limits (hv2-agent/src/script.rs)
+engine.set_max_expr_depths(50, 25);
+engine.set_max_operations(limits.max_operations);  // an infinite loop terminates here
+engine.set_max_string_size(limits.max_string_size);
 
-// No filesystem access by default
-// No network access by default
-// No system calls by default
+// The scope holds only a read-only view of the VM: state, name,
+// vCPU count, memory size. No filesystem, network or syscall
+// bindings are registered, and execution requires Capability::VmRead.
 ```
 
 ### T1610 - Deploy Container

--- a/docs/security/SECURITY_AUDIT.md
+++ b/docs/security/SECURITY_AUDIT.md
@@ -38,15 +38,17 @@ This document provides a comprehensive security audit of HyperMachine, covering:
 
 #### Resolved Vulnerabilities
 
-| ID                | Crate    | Version | Severity  | Status  | Resolution         |
-| ----------------- | -------- | ------- | --------- | ------- | ------------------ |
-| RUSTSEC-2025-0118 | wasmtime | 24.0.4  | Low (1.8) | ✅ FIXED | Upgraded to 24.0.5 |
+| ID                | Crate    | Version | Severity  | Status     | Resolution                |
+| ----------------- | -------- | ------- | --------- | ---------- | ------------------------- |
+| RUSTSEC-2025-0118 | wasmtime | 24.0.4  | Low (1.8) | ✅ REMOVED | Dependency deleted        |
 
 **RUSTSEC-2025-0118 Details:**
 - **Title:** Unsound API access to WebAssembly shared linear memory
 - **Description:** API provided unsound access to shared memory in multi-threaded contexts
 - **Impact:** Potential memory safety issues in WASM workloads
-- **Resolution:** Upgraded wasmtime from 24.0.4 to 24.0.5
+- **Resolution:** wasmtime was first upgraded to 24.0.5, then removed from the
+  workspace entirely. No source ever used it, so no WASM runtime is present and
+  this advisory class no longer applies.
 - **Verification:** `cargo audit` passes with no vulnerabilities
 
 #### Acknowledged Warnings (Unmaintained Crates)
@@ -55,10 +57,12 @@ These are transitive dependencies with no security vulnerabilities, only mainten
 
 | ID                | Crate   | Version | Root Cause                          | Risk Assessment                  |
 | ----------------- | ------- | ------- | ----------------------------------- | -------------------------------- |
-| RUSTSEC-2025-0141 | bincode | 1.3.3   | mbrman → bootloader                 | Low - stable, serialization only |
-| RUSTSEC-2025-0057 | fxhash  | 0.2.1   | fxprof-processed-profile → wasmtime | Low - hash algorithm, no CVEs    |
-| RUSTSEC-2024-0384 | instant | 0.1.13  | rhai                                | Low - time utilities, no CVEs    |
-| RUSTSEC-2024-0436 | paste   | 1.0.15  | wasmtime, wgpu                      | Low - macro utility, no CVEs     |
+| RUSTSEC-2025-0141 | bincode | 1.3.3   | direct dependency of hv2-core       | Low - stable, serialization only |
+| RUSTSEC-2024-0436 | paste   | 1.0.15  | image/rav1e → eframe → hm-gui       | Low - macro utility, no CVEs     |
+
+`fxhash` (RUSTSEC-2025-0057) and `instant` (RUSTSEC-2024-0384) were listed here
+previously. Neither is in the dependency graph any more: `fxhash` arrived through
+wasmtime, which has been removed, and `instant` was dropped by a newer `rhai`.
 
 **Mitigation Strategy:**
 - Monitor for security-relevant updates
@@ -108,7 +112,6 @@ audit_frequency = "weekly"
 | REST API     | Type-checked via serde | JSON schema validation   |
 | gRPC         | Protobuf schema        | Auto-validated           |
 | CLI          | clap type system       | Path canonicalization    |
-| WASM modules | wasmtime sandbox       | Memory limits enforced   |
 | VM configs   | Schema validation      | Resource bounds checking |
 
 ### 2.3 Cryptographic Controls


### PR DESCRIPTION
Dependabot opened #63 to bump wasmtime 24 → 48. **Nothing in the workspace uses wasmtime** — `grep -rl wasmtime --include=*.rs crates/` returns nothing. It was declared, made optional behind a `wasm-scripts` feature on `hv2-agent`, and that feature enables no code. Bumping a dependency nothing compiles buys nothing, so this removes it instead.

## The docs claimed more than that

Rhai scripting is real: `hv2-agent/src/script.rs` builds a Rhai engine with an operation cap, a string-size cap and expression-depth limits, gated on `Capability::VmRead`. WASM scripting was documented alongside it as though it were equally real.

- `docs/security/MITRE_ATTACK_MAPPING.md` claimed `Custom - WASM | wasmtime capability-based | ✅ Mitigated`, and showed a `Config::new()` / `consume_fuel` / `epoch_interruption` block **that exists nowhere in this repository**. Replaced with the Rhai limits actually applied.
- `docs/security/SECURITY_AUDIT.md` listed `WASM modules | wasmtime sandbox | Memory limits enforced` under input validation. There are no WASM modules.
- The `AgentSkill` description, the agent schema, the execute-script request schema and `docs/AGENTIC_ONTOLOGY.md` all offered `script_type: "wasm"` and base64-encoded WASM payloads. An API that accepts a value nothing implements is worse than one that does not offer it, so the enum is now `["rhai"]`.

## Incidental corrections in the same files

Two neighbouring facts were wrong for unrelated reasons, both checked with `cargo tree -i`:

- `bincode` is a **direct dependency of `hv2-core`** for snapshot serialisation, not something `bootloader` drags in via `mbrman`.
- `paste` arrives through `image`/`rav1e` under `eframe` in `hm-gui`, not through wasmtime/wgpu.

`fxhash` (RUSTSEC-2025-0057) and `instant` (RUSTSEC-2024-0384) were listed as acknowledged warnings and are no longer in the graph at all — `fxhash` came in through wasmtime, and `instant` was dropped by a newer `rhai`. The audit table says so now.

## Verification

| check | result |
| --- | --- |
| `cargo check --workspace --all-targets` | clean |
| `cargo test -p hv2-agent -p hv2-api` | all suites pass (509 in the main agent suite) |

Closes #63.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RsopUtvfyNzkKbbte56vZv