### PR TITLE
docs: name the legal entity as NERVOSYS, LLC

### DIFF
--- a/CLA.md
+++ b/CLA.md
@@ -1,11 +1,11 @@
 # Contributor License Agreement (CLA)
 
-**HyperMachine — Nervosys Contributor License Agreement v1.0**
+**HyperMachine — NERVOSYS, LLC Contributor License Agreement v1.0**
 
 Thank you for your interest in contributing to HyperMachine, a project
-maintained by Nervosys ("We", "Us", or "the Project"). This Contributor
-License Agreement ("Agreement") documents the rights granted by
-contributors to Nervosys.
+maintained by NERVOSYS, LLC ("Nervosys", "We", "Us", or "the Project").
+This Contributor License Agreement ("Agreement") documents the rights
+granted by contributors to Nervosys.
 
 By submitting a Contribution to this project, you accept and agree to the
 following terms and conditions for your present and future Contributions.

--- a/docs/book.toml
+++ b/docs/book.toml
@@ -1,6 +1,6 @@
 [book]
 title = "HyperMachine Documentation"
-authors = ["Nervosys"]
+authors = ["NERVOSYS, LLC"]
 description = "Agentic hypervisors for autonomous AI systems"
 language = "en"
 src = "src"

--- a/docs/security/BIS_TSU_NOTIFICATION.md
+++ b/docs/security/BIS_TSU_NOTIFICATION.md
@@ -77,7 +77,7 @@ We believe the software is classifiable under **ECCN 5D002** and qualifies for t
 
 | | |
 |--|--|
-| **Organization** | Nervosys |
+| **Organization** | NERVOSYS, LLC |
 | **Website** | https://nervosys.ai |
 
 ---


### PR DESCRIPTION
`LICENSE-COMMERCIAL` already reads `Copyright (c) 2026 NERVOSYS, LLC.` The CLA — the document granting the rights that commercial license depends on — named only "Nervosys", a trade name rather than the entity. For an agreement whose entire purpose is to transfer copyright and patent licenses to a specific party, that party should be identifiable.

The entity is now named where it is introduced and defined as `"Nervosys"` for the remainder of the document, so **every operative clause is textually unchanged**:

```diff
-**HyperMachine — Nervosys Contributor License Agreement v1.0**
+**HyperMachine — NERVOSYS, LLC Contributor License Agreement v1.0**

-maintained by Nervosys ("We", "Us", or "the Project"). This Contributor
-License Agreement ("Agreement") documents the rights granted by
-contributors to Nervosys.
+maintained by NERVOSYS, LLC ("Nervosys", "We", "Us", or "the Project").
+This Contributor License Agreement ("Agreement") documents the rights
+granted by contributors to Nervosys.
```

Two other places identify the organization and are corrected to match:

- `docs/security/BIS_TSU_NOTIFICATION.md` — a regulatory filing under 15 CFR §742.15(b) that names the submitting organization.
- `docs/book.toml` — documentation authorship metadata.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RsopUtvfyNzkKbbte56vZv