### PR TITLE
fix(ci): the CLA gate refused to run for the comment that signs it

### DIFF
--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -19,9 +19,17 @@ permissions:
 
 jobs:
   cla-check:
+    # Both comment bodies have to reach the action, not just `recheck`.
+    # While this listed `recheck` alone, the signing phrase was the one
+    # comment body the job refused to run for, so signing was impossible:
+    # the run appears in the Actions list as `issue_comment / skipped` and
+    # signatures/cla.json stays empty. The action's own README guards on
+    # both strings.
     if: |
       (github.event_name == 'pull_request_target') ||
-      (github.event_name == 'issue_comment' && github.event.comment.body == 'recheck')
+      (github.event_name == 'issue_comment' &&
+        (github.event.comment.body == 'recheck' ||
+         github.event.comment.body == 'I have read the CLA Document and I hereby sign the CLA'))
     runs-on: ubuntu-latest
     steps:
       - name: CLA Assistant


### PR DESCRIPTION
The job's condition admitted two events: any `pull_request_target`, and an `issue_comment` whose body is exactly `recheck`. **The signing phrase was not in the list**, so the one comment that records a signature was the one comment the job would not run for.

```yaml
# before
if: |
  (github.event_name == 'pull_request_target') ||
  (github.event_name == 'issue_comment' && github.event.comment.body == 'recheck')
```

The failure is silent from the pull request's side. The check simply stays red. The evidence is in the Actions list and the signatures branch:

```
2026-09-02T17:07:37Z   issue_comment   skipped   master
```
```json
{
   "signedContributors": []
}
```

Signing again does not help, because the second attempt is skipped for the same reason as the first. The action's own README guards on both strings; this restores the second.

## This is the third independent fault in one workflow

Each of these alone was enough to make signing impossible:

| fault | effect | fixed in |
| --- | --- | --- |
| `uses: ...@v2` — the action publishes only `vX.Y.Z` tags, so there is no `v2` | step never resolved | #75 |
| `branch: master` — the action commits `signatures/cla.json`, and `master` requires a pull request | write refused by ruleset | #75 |
| signing phrase absent from the `if:` guard | job skipped for the signing comment | **this PR** |

**The CLA check has never once recorded a signature since it was added.**

## Merge order

This has to reach `master` before anyone can sign, because `pull_request_target` and `issue_comment` both run the workflow from the **base** branch, not from the pull request. It therefore needs an admin merge — signing it first is impossible by construction.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RsopUtvfyNzkKbbte56vZv