### PR TITLE
fix(agent): VM identifiers could collide, and one VM would replace another

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2978,6 +2978,7 @@ dependencies = [
  "hv2-sandbox",
  "parking_lot",
  "proptest",
+ "rand 0.10.2",
  "rhai",
  "serde",
  "serde_json",

--- a/crates/hv2-agent/Cargo.toml
+++ b/crates/hv2-agent/Cargo.toml
@@ -25,6 +25,8 @@ anyhow = { workspace = true }
 thiserror = { workspace = true }
 tracing = { workspace = true }
 parking_lot = { workspace = true }
+# Identifiers come from the OS CSPRNG; see mcp::fresh_id.
+rand = { workspace = true }
 
 # Scripting engines
 rhai = { workspace = true }

--- a/crates/hv2-agent/src/communication.rs
+++ b/crates/hv2-agent/src/communication.rs
@@ -172,7 +172,7 @@ impl Message {
         payload: MessagePayload,
     ) -> Self {
         Self {
-            id: uuid_v4(),
+            id: crate::mcp::fresh_id(),
             sender: sender.into(),
             recipient: recipient.into(),
             message_type: MessageType::Info,
@@ -253,16 +253,6 @@ impl Message {
     pub fn is_response(&self) -> bool {
         self.message_type == MessageType::Response
     }
-}
-
-/// Generate a simple UUID v4
-fn uuid_v4() -> String {
-    use std::time::{SystemTime, UNIX_EPOCH};
-    let timestamp = SystemTime::now()
-        .duration_since(UNIX_EPOCH)
-        .unwrap_or_default()
-        .as_nanos();
-    format!("{:032x}", timestamp)
 }
 
 /// Agent registration info

--- a/crates/hv2-agent/src/mcp.rs
+++ b/crates/hv2-agent/src/mcp.rs
@@ -1972,7 +1972,7 @@ impl McpServer {
             }
         }
 
-        let session_id = format!("session-{}-{}", agent_id, uuid_v4());
+        let session_id = format!("session-{}-{}", agent_id, fresh_id());
         let session = Arc::new(AgentSession {
             id: session_id.clone(),
             agent_id: agent_id.to_string(),
@@ -2955,7 +2955,7 @@ impl McpServer {
                     .get("memory_gb")
                     .and_then(|v| v.as_u64())
                     .unwrap_or(4);
-                let vm_id = uuid_v4();
+                let vm_id = fresh_id();
 
                 // Record the VM in the session's owned_vms
                 session
@@ -3943,7 +3943,7 @@ impl AgentSession {
         parameters: JsonValue,
     ) -> ToolCallResponse {
         let request = ToolCallRequest {
-            id: uuid_v4(),
+            id: fresh_id(),
             tool: tool.to_string(),
             parameters,
             timeout: None,
@@ -3981,13 +3981,29 @@ impl AgentSession {
 }
 
 /// Generate a UUID v4 string
-pub(crate) fn uuid_v4() -> String {
-    use std::time::{SystemTime, UNIX_EPOCH};
-    let timestamp = SystemTime::now()
-        .duration_since(UNIX_EPOCH)
-        .unwrap_or_default()
-        .as_nanos();
-    format!("{:032x}", timestamp)
+/// A fresh 128-bit identifier, as 32 hex digits.
+///
+/// This was previously a hex-formatted nanosecond timestamp under the name
+/// `uuid_v4`. It was neither a UUID nor unique: two calls landing in the same
+/// clock tick returned the same string, and `LocalVmHost::create` inserts by
+/// that string, so the second VM silently replaced the first. `SystemTime`
+/// resolution is coarser on macOS than on Linux or Windows, which is where
+/// `list_reports_every_vm` caught it -- creating "a" then "b" and finding only
+/// "b".
+///
+/// The bytes come from the OS CSPRNG, so identifiers are unpredictable as well
+/// as distinct. Ownership is still enforced by the session and capability
+/// checks rather than by an identifier being hard to guess; this only stops
+/// one agent's VM from taking another's place by accident.
+pub(crate) fn fresh_id() -> String {
+    use rand::TryRng;
+    let mut bytes = [0u8; 16];
+    // A failure here means the OS random source is unavailable, which is not
+    // a condition this process can continue through safely.
+    rand::rng()
+        .try_fill_bytes(&mut bytes)
+        .expect("the OS random source is unavailable");
+    bytes.iter().map(|b| format!("{b:02x}")).collect()
 }
 
 #[cfg(test)]

--- a/crates/hv2-agent/src/vm_host.rs
+++ b/crates/hv2-agent/src/vm_host.rs
@@ -452,7 +452,7 @@ impl VmHost for LocalVmHost {
             }
         }
 
-        let vm_id = crate::mcp::uuid_v4();
+        let vm_id = crate::mcp::fresh_id();
         let hosted = HostedVm {
             vm: None,
             spec,
@@ -723,6 +723,41 @@ mod tests {
         names.sort();
 
         assert_eq!(names, vec!["a", "b"]);
+    }
+
+    /// VM ids were a hex nanosecond timestamp, so two VMs created inside one
+    /// clock tick shared an id and `insert` dropped the earlier one.
+    ///
+    /// Whether that collides is a property of the host clock -- macOS caught
+    /// it in `list_reports_every_vm` while Windows and Linux did not -- so
+    /// creating VMs in a loop and hoping for a duplicate does not test
+    /// anything reliably. This asserts the part that does not depend on
+    /// timing: ids must carry entropy rather than a clock reading.
+    ///
+    /// A nanosecond count since the epoch is around 2^61, and `{:032x}` pads
+    /// it to 32 digits, so every clock-derived id begins with sixteen zeros.
+    /// Random ids share no prefix at all beyond coincidence -- 64 of them
+    /// agreeing on even the first two digits has probability 256^-63.
+    #[tokio::test]
+    async fn vm_ids_carry_entropy_rather_than_a_clock_reading() {
+        let host = LocalVmHost::new();
+
+        let mut ids = Vec::new();
+        for i in 0..64 {
+            let vm = host.create(VmSpec::new(format!("vm-{i}"))).await.unwrap();
+            ids.push(vm.vm_id);
+        }
+
+        let first_two = &ids[0][..2];
+        assert!(
+            ids.iter().any(|id| &id[..2] != first_two),
+            "every id starts with {first_two:?}, so they are derived from              something shared -- a clock reading rather than entropy"
+        );
+
+        let unique: std::collections::HashSet<&String> = ids.iter().collect();
+        assert_eq!(unique.len(), ids.len(), "two VMs were given the same id");
+        assert_eq!(host.vm_count(), 64, "a VM was overwritten by another");
+        assert_eq!(host.list().await.unwrap().len(), 64);
     }
 
     #[tokio::test]


### PR DESCRIPTION
CI caught this on #80's macOS lane. It is unrelated to that PR — a pre-existing defect that only shows where the clock is coarse.

```
assertion `left == right` failed
  left:  ["b"]
 right:  ["a", "b"]
vm_host::tests::list_reports_every_vm
```

## The cause

`uuid_v4` was neither a UUID nor unique:

```rust
let timestamp = SystemTime::now()...as_nanos();
format!("{:032x}", timestamp)
```

Two calls landing in the same clock tick return the same string, and `LocalVmHost::create` ends with `self.vms.write().insert(vm_id, hosted)`. **The second VM replaces the first, silently** — no error, and `vm_count` reports one where two were created. macOS has coarser `SystemTime` resolution than Windows or Linux, which is why only that lane failed.

Identifiers now come from the OS CSPRNG, so they are distinct and unpredictable. Ownership is still enforced by session and capability checks rather than by an id being hard to guess — this stops one agent's VM from taking another's place by accident, nothing more.

The function is renamed `fresh_id` because it never produced a UUID, and the duplicate copy in `communication.rs` is deleted rather than fixed twice.

## On the test

Creating VMs in a loop and waiting for a duplicate only fails where the clock happens to be coarse — it proves nothing on the platforms where it passes, which is exactly the trap the original test fell into. **I wrote that test first, watched it pass against the broken generator on Windows, and threw it away.**

The test that shipped asserts the part that does not depend on timing. A nanosecond count since the epoch is about 2^61, and `{:032x}` pads it to 32 digits, so **every clock-derived id begins with sixteen zeros** while random ones share no prefix beyond coincidence.

Verified by putting the old generator back:

```
test vm_ids_carry_entropy_rather_than_a_clock_reading ... FAILED
```

and with the fix in place:

```
test vm_ids_carry_entropy_rather_than_a_clock_reading ... ok
test result: ok. 510 passed; 0 failed
```

| check | result |
| --- | --- |
| `cargo test -p hv2-agent` | 510 passed, 0 failed |
| `cargo clippy -p hv2-agent --all-targets -- -D warnings` | silent |
| `cargo fmt --all -- --check` | clean |

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RsopUtvfyNzkKbbte56vZv